### PR TITLE
remove: indexName uppercase

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = strapi => {
       const client = algoliasearch(applicationId, apiKey);
 
       const initIndex = (indexName) => {
-        return client.initIndex(`${prefix}_${indexName.toUpperCase()}`);
+        return client.initIndex(`${prefix}_${indexName}`);
       };
 
       strapi.services.algolia = {


### PR DESCRIPTION
- this implements #2 and removes the upper case transformation for `indexName`