### PR TITLE
Expose algoliasearch client to the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,28 @@ module.exports = {
 };
 ```
 
+**Using the algoliasearch client** 
+You can access the algolia javascript client, read the [official documentation](https://www.algolia.com/doc/api-reference/api-methods/) to know more.
+
+```js
+/**
+ * api/my-model/controllers/my-model.js
+ */
+
+module.exports = {
+  async myController(ctx) {
+    // ...
+
+    // https://www.algolia.com/doc/api-reference/api-methods/
+    const { client } = strapi.services.algolia
+    await client.listIndices()
+
+    // ...
+  },
+}
+```
+
+
 ## Hook config
 
 To activate and configure the hook, you need to create or update the file `./config/hook.js` in your strapi app.

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,10 @@ module.exports = strapi => {
       };
 
       strapi.services.algolia = {
+        /**
+         * Algoliasearch Client
+         */
+        client,
 
         /**
          * Saves the entity


### PR DESCRIPTION
This update allow to use the same client used by this hook in plugins or cronjobs 